### PR TITLE
✅ Add snapshots for distributions to avoid regressions

### DIFF
--- a/test/unit/distribution/UniformBigIntDistribution.spec.ts
+++ b/test/unit/distribution/UniformBigIntDistribution.spec.ts
@@ -50,5 +50,37 @@ describe('uniformBigIntDistribution', () => {
           }
         )
       ));
+    it.each`
+      from                       | to                         | topic
+      ${0}                       | ${2 ** 3 - 1}              | ${"range of size divisor of mersenne's one"}
+      ${0}                       | ${2 ** 3 - 2}              | ${"range of size divisor of mersenne's one minus one"}
+      ${0}                       | ${2 ** 3}                  | ${"range of size divisor of mersenne's one plus one"}
+      ${48}                      | ${69}                      | ${'random range'}
+      ${MERSENNE_MIN}            | ${MERSENNE_MAX}            | ${"mersenne's range"}
+      ${MERSENNE_MIN}            | ${MERSENNE_MAX - 1}        | ${"mersenne's range minus one"}
+      ${MERSENNE_MIN}            | ${MERSENNE_MAX + 1}        | ${"mersenne's range plus one"}
+      ${0}                       | ${2 ** 40 - 1}             | ${"range of size multiple of mersenne's one"}
+      ${0}                       | ${2 ** 40 - 2}             | ${"range of size multiple of mersenne's one minus one"}
+      ${0}                       | ${2 ** 40}                 | ${"range of size multiple of mersenne's one plus one"}
+      ${Number.MIN_SAFE_INTEGER} | ${Number.MAX_SAFE_INTEGER} | ${'full integer range'}
+    `('Should not change its output in range ($from, $to) except for major bumps', ({ from, to }) => {
+      // Remark:
+      // ========================
+      // This test is purely there to ensure that we do not introduce any regression
+      // during a commit without noticing it.
+      // The values we expect in the output are just a snapshot taken at a certain time
+      // in the past. They might be wrong values with bugs.
+
+      let rng = mersenne(0);
+      const distribution = uniformBigIntDistribution(BigInt(from), BigInt(to));
+
+      const values: bigint[] = [];
+      for (let idx = 0; idx !== 10; ++idx) {
+        const [v, nrng] = distribution(rng);
+        values.push(v);
+        rng = nrng;
+      }
+      expect(values).toMatchSnapshot();
+    });
   }
 });

--- a/test/unit/distribution/__snapshots__/UniformBigIntDistribution.spec.ts.snap
+++ b/test/unit/distribution/__snapshots__/UniformBigIntDistribution.spec.ts.snap
@@ -1,0 +1,166 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`uniformBigIntDistribution Should not change its output in range (-9007199254740991, 9007199254740991) except for major bumps 1`] = `
+Array [
+  8737460674931809n,
+  -2631724699627619n,
+  -4869445551762075n,
+  8293357854228373n,
+  5809860774060165n,
+  -1881172549903992n,
+  -7398457846580200n,
+  -5844702921965206n,
+  5236253499642215n,
+  2596198112838730n,
+]
+`;
+
+exports[`uniformBigIntDistribution Should not change its output in range (0, 6) except for major bumps 1`] = `
+Array [
+  4n,
+  3n,
+  0n,
+  2n,
+  1n,
+  2n,
+  6n,
+  3n,
+  4n,
+  5n,
+]
+`;
+
+exports[`uniformBigIntDistribution Should not change its output in range (0, 7) except for major bumps 1`] = `
+Array [
+  4n,
+  7n,
+  5n,
+  0n,
+  3n,
+  3n,
+  3n,
+  7n,
+  1n,
+  3n,
+]
+`;
+
+exports[`uniformBigIntDistribution Should not change its output in range (0, 8) except for major bumps 1`] = `
+Array [
+  8n,
+  0n,
+  2n,
+  6n,
+  7n,
+  6n,
+  7n,
+  1n,
+  1n,
+  0n,
+]
+`;
+
+exports[`uniformBigIntDistribution Should not change its output in range (0, 4294967294) except for major bumps 1`] = `
+Array [
+  2357136044n,
+  2546248239n,
+  3071714933n,
+  3626093760n,
+  2588848963n,
+  3684848379n,
+  2340255427n,
+  3638918503n,
+  1819583497n,
+  2678185683n,
+]
+`;
+
+exports[`uniformBigIntDistribution Should not change its output in range (0, 4294967295) except for major bumps 1`] = `
+Array [
+  2357136044n,
+  2546248239n,
+  3071714933n,
+  3626093760n,
+  2588848963n,
+  3684848379n,
+  2340255427n,
+  3638918503n,
+  1819583497n,
+  2678185683n,
+]
+`;
+
+exports[`uniformBigIntDistribution Should not change its output in range (0, 4294967296) except for major bumps 1`] = `
+Array [
+  189112195n,
+  554378827n,
+  1095999416n,
+  1298663076n,
+  858602186n,
+  3171780062n,
+  3693445940n,
+  708411795n,
+  1327117109n,
+  404687239n,
+]
+`;
+
+exports[`uniformBigIntDistribution Should not change its output in range (0, 1099511627774) except for major bumps 1`] = `
+Array [
+  741289830713n,
+  506149266278n,
+  291457769902n,
+  841166682845n,
+  41339999095n,
+  91856056387n,
+  155904065550n,
+  300906252564n,
+  379144339494n,
+  251166092282n,
+]
+`;
+
+exports[`uniformBigIntDistribution Should not change its output in range (0, 1099511627775) except for major bumps 1`] = `
+Array [
+  741280623151n,
+  506137267392n,
+  291447657211n,
+  841157541223n,
+  41332891347n,
+  91845220082n,
+  155896724055n,
+  300891291096n,
+  379128171916n,
+  251159659201n,
+]
+`;
+
+exports[`uniformBigIntDistribution Should not change its output in range (0, 1099511627776) except for major bumps 1`] = `
+Array [
+  741271415589n,
+  506125268506n,
+  291437544520n,
+  841148399601n,
+  41325783599n,
+  91834383777n,
+  155889382560n,
+  300876329628n,
+  379112004338n,
+  251153226120n,
+]
+`;
+
+exports[`uniformBigIntDistribution Should not change its output in range (48, 69) except for major bumps 1`] = `
+Array [
+  58n,
+  55n,
+  49n,
+  62n,
+  67n,
+  51n,
+  63n,
+  59n,
+  65n,
+  67n,
+]
+`;

--- a/test/unit/distribution/__snapshots__/UniformIntDistribution.spec.ts.snap
+++ b/test/unit/distribution/__snapshots__/UniformIntDistribution.spec.ts.snap
@@ -1,0 +1,166 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`uniformIntDistribution Should not change its output in range (-9007199254740991, 9007199254740991) except for major bumps 1`] = `
+Array [
+  8737460674930689,
+  -2631724699627519,
+  -4869445551763455,
+  8293357854228481,
+  5809860774060033,
+  -1881172549904383,
+  -7398457846580223,
+  -5844702921965567,
+  5236253499641857,
+  2596198112838657,
+]
+`;
+
+exports[`uniformIntDistribution Should not change its output in range (0, 6) except for major bumps 1`] = `
+Array [
+  4,
+  3,
+  0,
+  2,
+  1,
+  2,
+  6,
+  3,
+  4,
+  5,
+]
+`;
+
+exports[`uniformIntDistribution Should not change its output in range (0, 7) except for major bumps 1`] = `
+Array [
+  4,
+  7,
+  5,
+  0,
+  3,
+  3,
+  3,
+  7,
+  1,
+  3,
+]
+`;
+
+exports[`uniformIntDistribution Should not change its output in range (0, 8) except for major bumps 1`] = `
+Array [
+  8,
+  0,
+  2,
+  6,
+  7,
+  6,
+  7,
+  1,
+  1,
+  0,
+]
+`;
+
+exports[`uniformIntDistribution Should not change its output in range (0, 4294967294) except for major bumps 1`] = `
+Array [
+  2357136044,
+  2546248239,
+  3071714933,
+  3626093760,
+  2588848963,
+  3684848379,
+  2340255427,
+  3638918503,
+  1819583497,
+  2678185683,
+]
+`;
+
+exports[`uniformIntDistribution Should not change its output in range (0, 4294967295) except for major bumps 1`] = `
+Array [
+  2357136044,
+  2546248239,
+  3071714933,
+  3626093760,
+  2588848963,
+  3684848379,
+  2340255427,
+  3638918503,
+  1819583497,
+  2678185683,
+]
+`;
+
+exports[`uniformIntDistribution Should not change its output in range (0, 4294967296) except for major bumps 1`] = `
+Array [
+  189112320,
+  554379264,
+  1095999488,
+  1298663424,
+  858602496,
+  3171780608,
+  3693446144,
+  708411392,
+  1327118336,
+  404687872,
+]
+`;
+
+exports[`uniformIntDistribution Should not change its output in range (0, 1099511627774) except for major bumps 1`] = `
+Array [
+  741289830400,
+  506149267456,
+  291457769472,
+  841166684160,
+  41339999232,
+  91856056320,
+  155904065536,
+  300906252288,
+  379144339456,
+  251166092288,
+]
+`;
+
+exports[`uniformIntDistribution Should not change its output in range (0, 1099511627775) except for major bumps 1`] = `
+Array [
+  741280622592,
+  506137268224,
+  291447656448,
+  841157541888,
+  41332891648,
+  91845220352,
+  155896724480,
+  300891291648,
+  379128172544,
+  251159659520,
+]
+`;
+
+exports[`uniformIntDistribution Should not change its output in range (0, 1099511627776) except for major bumps 1`] = `
+Array [
+  741271414784,
+  506125268992,
+  291437543424,
+  841148399616,
+  41325784064,
+  91834384384,
+  155889383424,
+  300876331008,
+  379112005632,
+  251153226752,
+]
+`;
+
+exports[`uniformIntDistribution Should not change its output in range (48, 69) except for major bumps 1`] = `
+Array [
+  58,
+  55,
+  49,
+  62,
+  67,
+  51,
+  63,
+  59,
+  65,
+  67,
+]
+`;


### PR DESCRIPTION
'Avoid' or more precisely 'Detect them earlier'