### PR TITLE
🔨 Reports for benchmarks expose a confidence range option

### DIFF
--- a/perf/benchmark.cjs
+++ b/perf/benchmark.cjs
@@ -57,7 +57,7 @@ const argv = yargs(hideBin(process.argv))
   .option('print-confidence', {
     type: 'boolean',
     default: false,
-    description: 'Print confidence range in reports',
+    description: 'Print 95 % confidence range in reports instead of +X% (increase the number of samples to reduce this range)',
   })
   .option('verbose', {
     alias: 'v',

--- a/perf/benchmark.cjs
+++ b/perf/benchmark.cjs
@@ -348,7 +348,7 @@ async function run() {
           ...Object.fromEntries(
             configurations.map((config, configIndex) => {
               if (configIndex === currentConfigIndex) {
-                return [config[0], '-'];
+                return [config[0], '—'];
               }
               const otherBenchStats = benchmarkStatsFor(configIndex, testIndex);
               const otherBenchWorst = Math.max(Number.MIN_VALUE, otherBenchStats.mean - 2 * otherBenchStats.deviation);

--- a/perf/benchmark.cjs
+++ b/perf/benchmark.cjs
@@ -323,7 +323,7 @@ async function run() {
     const table = new Table({
       columns: [
         { name: 'Name', alignment: 'left' },
-        ...configurations.map(([configName]) => ({ name: configName, alignment: 'right' })),
+        ...configurations.map(([configName]) => ({ name: configName, alignment: 'center' })),
       ],
     });
     // Find the best and worst configurations


### PR DESCRIPTION
`--print-confidence`

⚠️ This flag require our users to have stable runs. The higher `-s` options will be the smaller will be this confidence range.