### PR TITLE
🔒️ Disable pnpm cache on push for production_package job

### DIFF
--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -407,7 +407,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: '24.14.1'
-          cache: 'pnpm'
+          cache: ${{ github.event_name != 'push' && 'pnpm' || '' }}
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Build production package


### PR DESCRIPTION
For push events, the production_package job now skips the pnpm cache on
setup-node so the build runs against a fresh dependency install.