### PR TITLE
🔒 Add --ignore-scripts to pnpm install/add in CI

### DIFF
--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -31,7 +31,7 @@ jobs:
           cache: 'pnpm'
       - name: Update pnpm cache
         if: steps.pnpm-cache.outputs.cache-hit != 'true'
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
   # Validation jobs
   no_dedupe_required:
@@ -63,7 +63,7 @@ jobs:
           node-version: '24.14.1'
           cache: 'pnpm'
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
       - name: Check format
         run: pnpm format:check
   typecheck:
@@ -80,7 +80,7 @@ jobs:
           node-version: '24.14.1'
           cache: 'pnpm'
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
       - name: Check types
         run: pnpm typecheck
   bench:
@@ -98,7 +98,7 @@ jobs:
           node-version: 24.14.1
           cache: 'pnpm'
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
       - name: Bench tests
         id: bench
         run: pnpm bench | tee bench-output.txt
@@ -384,7 +384,7 @@ jobs:
           node-version: ${{matrix.node-version}}
           cache: 'pnpm'
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
       - name: Unit tests
         run: pnpm test --coverage
       - name: Codecov
@@ -409,7 +409,7 @@ jobs:
           node-version: '24.14.1'
           cache: 'pnpm'
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
       - name: Build production package
         run: pnpm build
         env:
@@ -458,7 +458,7 @@ jobs:
           node-version: '24.14.1'
           cache: 'pnpm'
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
       - name: Download production packages
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/compare.yml
+++ b/.github/workflows/compare.yml
@@ -14,9 +14,9 @@ jobs:
           node-version: '24.14.1'
           cache: 'pnpm'
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
       - name: Install extra libraries
-        run: pnpm add chance@1.1.10 @faker-js/faker@7.6.0 random-js@2.1.0 seedrandom@3.0.5 --save-exact
+        run: pnpm add chance@1.1.10 @faker-js/faker@7.6.0 random-js@2.1.0 seedrandom@3.0.5 --save-exact --ignore-scripts
       - name: Build package
         run: pnpm build
       - name: Env Info


### PR DESCRIPTION
Prevent execution of dependency lifecycle scripts during CI installs to
reduce supply chain attack surface.