### PR TITLE
👷 Replace `pnpm dlx` with `pnpm exec` for `pkg-pr-new`

### DIFF
--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -436,10 +436,10 @@ jobs:
           key: bundle-main-${{ github.sha }}
       - name: Preview (no comment)
         if: github.event_name != 'pull_request'
-        run: pnpm dlx pkg-pr-new publish --compact --comment=off
+        run: pnpm exec pkg-pr-new publish --compact --comment=off
       - name: Preview
         if: github.event_name == 'pull_request'
-        run: pnpm dlx pkg-pr-new publish --compact
+        run: pnpm exec pkg-pr-new publish --compact
 
   # Post-build jobs
   test_bundle:


### PR DESCRIPTION
## Summary
Updated the build workflow to use `pnpm exec` instead of `pnpm dlx` when running the `pkg-pr-new` publish command.

## Key Changes
- Changed `pnpm dlx pkg-pr-new publish` to `pnpm exec pkg-pr-new publish` in the "Preview (no comment)" job
- Changed `pnpm dlx pkg-pr-new publish` to `pnpm exec pkg-pr-new publish` in the "Preview" job

## Details
This change replaces the `dlx` command (which downloads and executes packages on-the-fly) with `exec` (which runs locally installed packages). This approach is more efficient in CI environments where dependencies are already installed and cached, reducing unnecessary downloads and improving workflow execution time.

https://claude.ai/code/session_017mcuCWa1KkTQvDNAseRSVP