### PR TITLE
🔨 Use envs for package size outputs in PR comment

### DIFF
--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -216,6 +216,10 @@ jobs:
           name: size-output
       - name: Comment package size on PR
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          TGZ_SIZE: ${{ needs.package_size.outputs.tgzSize }}
+          MAIN_TGZ_SIZE: ${{ needs.package_size.outputs.mainTgzSize }}
+          LAST_PUBLISHED_VERSION: ${{ needs.package_size.outputs.lastPublishedVersion }}
         with:
           script: |
             // Extract details on files
@@ -331,9 +335,9 @@ jobs:
             }
 
             // Build summary header: new size vs main vs published
-            const tgzSize = Number("${{ needs.package_size.outputs.tgzSize }}");
-            const mainTgzSize = Number("${{ needs.package_size.outputs.mainTgzSize }}") || 0;
-            const lastPublishedVersion = "${{ needs.package_size.outputs.lastPublishedVersion }}";
+            const tgzSize = Number(process.env.TGZ_SIZE);
+            const mainTgzSize = Number(process.env.MAIN_TGZ_SIZE) || 0;
+            const lastPublishedVersion = process.env.LAST_PUBLISHED_VERSION;
 
             let summary = `**New size:** ${formatBytes(totalNew)} (tgz: ${formatBytes(tgzSize)})`;
 


### PR DESCRIPTION
## Summary
Refactored the GitHub Actions workflow to pass package size outputs as environment variables instead of directly interpolating them into the script context.

## Key Changes
- Added `env` section to the "Comment package size on PR" step that exports three outputs as environment variables:
  - `TGZ_SIZE`: The compressed package size
  - `MAIN_TGZ_SIZE`: The main branch package size
  - `LAST_PUBLISHED_VERSION`: The last published version
- Updated the script to read these values from `process.env` instead of using GitHub Actions context interpolation (`${{ }}`)

## Implementation Details
This change improves the separation of concerns by using environment variables as the interface between the workflow outputs and the script logic. This approach:
- Makes the script more testable and portable
- Reduces reliance on GitHub Actions-specific syntax within the script
- Maintains the same functionality while improving code clarity

https://claude.ai/code/session_01211B8gFpzmPuoVKik2NoMg