### PR TITLE
👷 Add workflow security audit with zizmor

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,34 @@
+name: Workflow Security Audit
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+    branches:
+      - main
+      - next-*
+      - fix-v*
+  push:
+    branches:
+      - main
+      - next-*
+      - fix-v*
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  audit:
+    name: 'Audit GitHub Actions workflows'
+    if: github.event_name == 'push' || github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'reopened' || (github.event.action == 'labeled' && github.event.label.name == 'force-build-status-execution')
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3


### PR DESCRIPTION
## Summary
This PR adds automated security auditing of GitHub Actions workflows using the zizmor tool. This helps identify and prevent common security misconfigurations in workflow files.

## Key Changes
- Added new workflow file `.github/workflows/zizmor.yml` that runs security audits on GitHub Actions workflows
- Configured to run on push and pull request events for main and release branches (next-*, fix-v*)
- Uses zizmor-action to scan workflows for security issues and report findings via SARIF format
- Includes concurrency controls to cancel in-progress runs when new events are triggered
- Minimal permissions set (security-events: write only) following the principle of least privilege

## Implementation Details
- Triggers on: push to main/next-*/fix-v* branches and PRs (opened, synchronize, reopened, or labeled with 'force-build-status-execution')
- Runs on ubuntu-latest with checkout action pinned to v6.0.2
- Uses zizmor-action v0.5.3 to perform the security audit
- Results are written as security events for visibility in GitHub's security tab

https://claude.ai/code/session_01FvfzppcSn16Cn9fvb6vSt4