### PR TITLE
👷 Lock down workflow permissions to least-privilege

### DIFF
--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -14,6 +14,8 @@ on:
       - next-*
       - fix-v*
 
+permissions: {}
+
 jobs:
   # Job to prepare pnpm cache (pre-requisite for any job installing dependencies)
   warmup_pnpm_cache:
@@ -114,6 +116,8 @@ jobs:
     needs: bench
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Download bench results
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -403,6 +407,10 @@ jobs:
     name: 'Build production package'
     needs: warmup_pnpm_cache
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install pnpm

--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -14,7 +14,8 @@ on:
       - next-*
       - fix-v*
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   # Job to prepare pnpm cache (pre-requisite for any job installing dependencies)

--- a/.github/workflows/compare.yml
+++ b/.github/workflows/compare.yml
@@ -1,7 +1,8 @@
 name: Compare
 on: workflow_dispatch
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   compare:

--- a/.github/workflows/compare.yml
+++ b/.github/workflows/compare.yml
@@ -1,5 +1,8 @@
 name: Compare
 on: workflow_dispatch
+
+permissions: {}
+
 jobs:
   compare:
     name: 'Compare'


### PR DESCRIPTION
## Summary

Addresses zizmor's `excessive-permissions` audit (13 findings: 12 in `build-status.yml`, 1 in `compare.yml`).

Neither workflow declared a top-level `permissions:` block, so every job inherited the repository's default `GITHUB_TOKEN` scopes — historically write access to most scopes. A compromised third-party action or script-injection finding then runs with that excess authority.

### Approach (matches fast-check)

1. **Workflow-level `permissions: contents: read`** — same as [`dubzzz/fast-check`](https://github.com/dubzzz/fast-check/blob/main/.github/workflows/build-status.yml). Only the read-only `contents` scope by default; every job that needs more must opt in explicitly.
2. **Per-job `permissions:`** — minimum each job actually needs.

### Per-job permissions added

| Workflow | Job | Permissions | Why |
|---|---|---|---|
| `build-status.yml` | *(workflow default)* | `contents: read` | Read-only baseline. |
| `build-status.yml` | `comment_bench` | `pull-requests: write` | Posts/updates the benchmark comment via `github-script`. |
| `build-status.yml` | `production_package` | `actions: write`, `contents: read`, `id-token: write` | `gh cache delete` needs `actions: write`; checkout needs `contents: read`; `pkg-pr-new publish` uses OIDC (`id-token: write`). |
| `compare.yml` | *(workflow default)* | `contents: read` | Read-only benchmark workflow. |

Jobs that already had a correct `permissions:` block — `package_size` (`{}`), `comment_package_size` (`pull-requests: write`), `publish_package` (`contents: read` + `id-token: write`) — are untouched. Other workflows (`zizmor.yml`, `mirror-tangled.yml`, `claude.yml`, `claude-review.yml`) already declared correct permissions.

### Alternatives considered

- **Top-level `permissions: {}`** — Stricter (zero scope by default). Initially used, but switched to `contents: read` to match fast-check, since every actively-used job here needs to read repo contents and the workflow-wide read is harmless.
- **Top-level `permissions: read-all`** — Too loose; grants scopes (`actions`, `packages`, `metadata`) no job in this workflow reads.
- **Blanket `pull-requests: write` at workflow level** — Would leak PR-comment write capability to every job (test, build, bench).

After this PR: `zizmor` reports **0** `excessive-permissions` findings.

## Test plan
- [ ] CI runs and all jobs succeed (notably `comment_bench` still posts to the PR; `production_package` can still delete old caches and publish preview to pkg-pr-new).
- [ ] `zizmor .github/workflows/` reports 0 `excessive-permissions` findings.