### PR TITLE
👷 Suppress zizmor use-trusted-publishing on pkg-pr-new

### DIFF
--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -440,10 +440,10 @@ jobs:
           key: bundle-main-${{ github.sha }}
       - name: Preview (no comment)
         if: github.event_name != 'pull_request'
-        run: pnpm exec pkg-pr-new publish --compact --comment=off
+        run: pnpm exec pkg-pr-new publish --compact --comment=off # zizmor: ignore[use-trusted-publishing]
       - name: Preview
         if: github.event_name == 'pull_request'
-        run: pnpm exec pkg-pr-new publish --compact
+        run: pnpm exec pkg-pr-new publish --compact # zizmor: ignore[use-trusted-publishing]
 
   # Post-build jobs
   test_bundle:


### PR DESCRIPTION
## Summary

Addresses zizmor's `use-trusted-publishing` audit (2 info-level findings in `build-status.yml`).

The audit pattern-matches publish-like commands (`*publish*`) and recommends OIDC trusted publishing instead of long-lived tokens. It fires on the two `pnpm exec pkg-pr-new publish` invocations in the `production_package` job.

### Why this is a false positive

[`pkg-pr-new`](https://github.com/stackblitz-labs/pkg-pr-new) is a per-commit **preview-package** service — it builds an ephemeral tarball hosted on its own infrastructure for each PR/commit. It does not publish to npm and does not accept npm tokens; it already authenticates via GitHub Actions OIDC out-of-the-box. So "switch to trusted publishing" doesn't apply: there's no registry token to swap.

The real `npm publish` (line 569, `publish_package` job) is unrelated and already uses `--provenance` + `id-token: write`, which **is** trusted publishing.

### Fix

Inline `# zizmor: ignore[use-trusted-publishing]` on the two affected lines, with the rationale colocated:

```yaml
run: pnpm exec pkg-pr-new publish --compact --comment=off # zizmor: ignore[use-trusted-publishing]
```

### Alternatives considered

- **`.github/zizmor.yml` rule ignore** (the pattern used in [fast-check's zizmor.yml](https://github.com/dubzzz/fast-check/blob/main/.github/zizmor.yml), which lists `build-status.yml:213` and `build-status.yml:216`). Equally valid. Inline was chosen here because the suppression is hyper-local (two specific commands), the rationale is more discoverable next to the line, and it survives line-number drift better than path:line entries that need updating whenever the workflow is reordered. Happy to switch to the config-file form if you prefer consistency with fast-check.
- **Leave unaddressed** — `use-trusted-publishing` is info-level so doesn't fail the audit. We chose to suppress so the audit signal stays clean and any new finding (e.g. a real publish step added later) isn't lost in noise.

After this PR: `zizmor` reports **0** `use-trusted-publishing` findings.

## Test plan
- [ ] `zizmor .github/workflows/` reports 0 `use-trusted-publishing` findings.
- [ ] `pkg-pr-new` preview still publishes on PR / non-PR runs as before (workflow logic unchanged).

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBVfs5U4cNQZHDSZKoFEDr)_