### PR TITLE
👷 Switch publish flow to `npm stage publish`

### DIFF
--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -553,15 +553,12 @@ jobs:
           node-version: '24.15.0'
           registry-url: 'https://registry.npmjs.org'
       - name: Install npm version supporting stage publish
-        run: npm install -g npm@latest
+        run: cd .. && npm install -g npm@latest
       - name: Download production package
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: bundle
       - name: Publish package
-        run: |
-          mv package.tgz ..
-          cd ..
-          npm stage publish --provenance --access public package.tgz
+        run: cd .. && npm stage publish --provenance --access public "$GITHUB_WORKSPACE/package.tgz"
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -552,21 +552,16 @@ jobs:
         with:
           node-version: '24.15.0'
           registry-url: 'https://registry.npmjs.org'
-      - name: Install latest npm version
-        run: npm install -g npm
+      - name: Install npm version supporting stage publish
+        run: npm install -g npm@latest
       - name: Download production package
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: bundle
-      - uses: step-security/wait-for-secrets@084b3ae774c0e0003a9307ae4f487c10f1f998fe # v1.2.1
-        id: wait-for-secrets
-        with:
-          secrets: |
-            OTP:
-              name: 'OTP to publish package'
-              description: 'OTP from authenticator app'
       - name: Publish package
-        run: npm publish --provenance --access public --otp "$OTP_VALUE" package.tgz
+        run: |
+          mv package.tgz ..
+          cd ..
+          npm stage publish --provenance --access public package.tgz
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-          OTP_VALUE: ${{steps.wait-for-secrets.outputs.OTP}}


### PR DESCRIPTION
Use `npm stage publish` to support staged releases. Move the tarball
outside the repo before publishing so the `packageManager` field
doesn't block npm. Drop the manual OTP wait/flag now that publishing
relies on OIDC trusted publishing.