### PR TITLE
👷 Add bench comparing faker vs faker+pure-rand

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
   },
   "homepage": "https://github.com/dubzzz/pure-rand#readme",
   "devDependencies": {
+    "@faker-js/faker": "^10.4.0",
     "@fast-check/packaged": "^0.7.0",
     "@vitest/coverage-v8": "4.1.6",
     "fast-check": "^4.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@faker-js/faker':
+        specifier: ^10.4.0
+        version: 10.4.0
       '@fast-check/packaged':
         specifier: ^0.7.0
         version: 0.7.0
@@ -247,6 +250,10 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@faker-js/faker@10.4.0':
+    resolution: {integrity: sha512-sDBWI3yLy8EcDzgobvJTWq1MJYzAkQdpjXuPukga9wXonhpMRvd1Izuo2Qgwey2OiEoRIBr35RMU9HJRoOHzpw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || ^23.5.0 || >=24.0.0, npm: '>=10'}
 
   '@fast-check/packaged@0.7.0':
     resolution: {integrity: sha512-oVf70XMfnxUrm55xzVphQguzMBCKU5gCMcY1rDX6gRpCh8OfNUWefeQ2HG9nG59RtcXIrsEzeWP65D+LoKYVSQ==}
@@ -1602,6 +1609,8 @@ snapshots:
 
   '@esbuild/win32-x64@0.27.3':
     optional: true
+
+  '@faker-js/faker@10.4.0': {}
 
   '@fast-check/packaged@0.7.0':
     dependencies:

--- a/src/faker.bench.ts
+++ b/src/faker.bench.ts
@@ -21,10 +21,14 @@ import { xoroshiro128plus } from './generator/xoroshiro128plus';
 import { xorshift128plus } from './generator/xorshift128plus';
 import type { RandomGenerator } from './types/RandomGenerator';
 
-function generatePureRandRandomizer(factory: (seed: number) => RandomGenerator, initialSeed: number): Randomizer {
+function generatePureRandRandomizer(
+  factory: (seed: number) => RandomGenerator,
+  initialSeed: number,
+  toFloat: (rng: RandomGenerator) => number,
+): Randomizer {
   const self: { generator: RandomGenerator } & Randomizer = {
     generator: factory(initialSeed),
-    next: () => uniformFloat64(self.generator),
+    next: () => toFloat(self.generator),
     seed: (value) => {
       self.generator = factory(typeof value === 'number' ? value : (value[0] ?? 0));
     },
@@ -32,15 +36,34 @@ function generatePureRandRandomizer(factory: (seed: number) => RandomGenerator, 
   return self;
 }
 
+// Non-uniform transform: 32-bit precision packed into a 53-bit float. Matches
+// faker's own `nextF32` path used by `generateMersenne32Randomizer`.
+function nonUniformFloat32(rng: RandomGenerator): number {
+  return (rng.next() >>> 0) / 0x1_0000_0000;
+}
+
 type Variant = { name: string; build: (seed: number) => Randomizer };
 
+const pureRandFactories: { name: string; factory: (seed: number) => RandomGenerator }[] = [
+  { name: 'xoroshiro128plus', factory: xoroshiro128plus },
+  { name: 'xorshift128plus', factory: xorshift128plus },
+  { name: 'mersenne', factory: mersenne },
+  { name: 'congruential32', factory: congruential32 },
+];
+
 const variants: Variant[] = [
-  { name: 'faker @@ mersenne32 (default <v9)', build: (seed) => generateMersenne32Randomizer(seed) },
-  { name: 'faker @@ mersenne53 (default >=v9)', build: (seed) => generateMersenne53Randomizer(seed) },
-  { name: 'pure-rand @@ xoroshiro128plus', build: (seed) => generatePureRandRandomizer(xoroshiro128plus, seed) },
-  { name: 'pure-rand @@ xorshift128plus', build: (seed) => generatePureRandRandomizer(xorshift128plus, seed) },
-  { name: 'pure-rand @@ mersenne', build: (seed) => generatePureRandRandomizer(mersenne, seed) },
-  { name: 'pure-rand @@ congruential32', build: (seed) => generatePureRandRandomizer(congruential32, seed) },
+  { name: 'faker @@ mersenne32 (default <v9) [non-uniform]', build: (seed) => generateMersenne32Randomizer(seed) },
+  { name: 'faker @@ mersenne53 (default >=v9) [uniform]', build: (seed) => generateMersenne53Randomizer(seed) },
+  ...pureRandFactories.flatMap(({ name, factory }): Variant[] => [
+    {
+      name: `pure-rand @@ ${name} [non-uniform]`,
+      build: (seed) => generatePureRandRandomizer(factory, seed, nonUniformFloat32),
+    },
+    {
+      name: `pure-rand @@ ${name} [uniform]`,
+      build: (seed) => generatePureRandRandomizer(factory, seed, uniformFloat64),
+    },
+  ]),
 ];
 
 // `[en, base]` is the minimum set needed for richer modules such as

--- a/src/faker.bench.ts
+++ b/src/faker.bench.ts
@@ -12,6 +12,7 @@ import {
   generateMersenne53Randomizer,
   type Randomizer,
 } from '@faker-js/faker';
+import { uniformFloat64 } from './distribution/uniformFloat64';
 import { congruential32 } from './generator/congruential32';
 import { mersenne } from './generator/mersenne';
 import { xoroshiro128plus } from './generator/xoroshiro128plus';
@@ -21,7 +22,7 @@ import type { RandomGenerator } from './types/RandomGenerator';
 function generatePureRandRandomizer(factory: (seed: number) => RandomGenerator, initialSeed: number): Randomizer {
   const self: { generator: RandomGenerator } & Randomizer = {
     generator: factory(initialSeed),
-    next: () => (self.generator.next() >>> 0) / 0x1_0000_0000,
+    next: () => uniformFloat64(self.generator),
     seed: (value) => {
       self.generator = factory(typeof value === 'number' ? value : (value[0] ?? 0));
     },

--- a/src/faker.bench.ts
+++ b/src/faker.bench.ts
@@ -7,9 +7,11 @@
 import { describe, bench } from 'vitest';
 import {
   Faker,
+  base,
   en,
   generateMersenne32Randomizer,
   generateMersenne53Randomizer,
+  type LocaleDefinition,
   type Randomizer,
 } from '@faker-js/faker';
 import { uniformFloat64 } from './distribution/uniformFloat64';
@@ -41,6 +43,9 @@ const variants: Variant[] = [
   { name: 'pure-rand @@ congruential32', build: (seed) => generatePureRandRandomizer(congruential32, seed) },
 ];
 
+// `[en, base]` is the minimum set needed for richer modules such as
+// `person.bio()` which falls back to `internet.emoji` from `base`.
+const locale: LocaleDefinition[] = [en, base];
 const numCalls = 5_000;
 
 describe('faker', () => {
@@ -57,7 +62,7 @@ describe('faker', () => {
 
   describe('faker.person.fullName()', () => {
     for (const { name, build } of variants) {
-      const faker = new Faker({ locale: en, randomizer: build(0) });
+      const faker = new Faker({ locale, randomizer: build(0) });
       bench(name, () => {
         faker.person.fullName();
       });
@@ -66,7 +71,7 @@ describe('faker', () => {
 
   describe('faker.internet.email()', () => {
     for (const { name, build } of variants) {
-      const faker = new Faker({ locale: en, randomizer: build(0) });
+      const faker = new Faker({ locale, randomizer: build(0) });
       bench(name, () => {
         faker.internet.email();
       });
@@ -74,11 +79,57 @@ describe('faker', () => {
   });
 
   describe('faker.helpers.shuffle (1_000 items)', () => {
-    const data = Array.from({ length: 1_000 }, (_, i) => i);
+    const data: number[] = [];
+    for (let i = 0; i !== 1_000; ++i) {
+      data.push(i);
+    }
     for (const { name, build } of variants) {
-      const faker = new Faker({ locale: en, randomizer: build(0) });
+      const faker = new Faker({ locale, randomizer: build(0) });
       bench(name, () => {
         faker.helpers.shuffle(data);
+      });
+    }
+  });
+
+  describe('faker.string.uuid()', () => {
+    for (const { name, build } of variants) {
+      const faker = new Faker({ locale, randomizer: build(0) });
+      bench(name, () => {
+        faker.string.uuid();
+      });
+    }
+  });
+
+  describe('faker.lorem.paragraphs(10)', () => {
+    for (const { name, build } of variants) {
+      const faker = new Faker({ locale, randomizer: build(0) });
+      bench(name, () => {
+        faker.lorem.paragraphs(10);
+      });
+    }
+  });
+
+  // Full user-like record — exercises many faker modules at once and emulates a
+  // realistic seeding workload (e.g. populating a database with fixtures).
+  describe('faker @@ full user record', () => {
+    for (const { name, build } of variants) {
+      const faker = new Faker({ locale, randomizer: build(0) });
+      bench(name, () => {
+        ({
+          id: faker.string.uuid(),
+          firstName: faker.person.firstName(),
+          lastName: faker.person.lastName(),
+          jobTitle: faker.person.jobTitle(),
+          bio: faker.person.bio(),
+          email: faker.internet.email(),
+          phone: faker.phone.number(),
+          street: faker.location.streetAddress(),
+          city: faker.location.city(),
+          country: faker.location.country(),
+          company: faker.company.name(),
+          iban: faker.finance.iban(),
+          creditCard: faker.finance.creditCardNumber(),
+        });
       });
     }
   });

--- a/src/faker.bench.ts
+++ b/src/faker.bench.ts
@@ -1,0 +1,84 @@
+// Benchmark comparing the default Mersenne-based randomizer shipped by faker
+// against pure-rand generators wired in through a small `generatePureRandRandomizer`
+// adapter — the very integration unlocked by the closed feature request
+// faker-js/faker#2195 ("Customize the PRNG used by faker"),
+// see https://github.com/faker-js/faker/issues/2195 and the resulting guide
+// at https://fakerjs.dev/guide/randomizer.
+import { describe, bench } from 'vitest';
+import {
+  Faker,
+  en,
+  generateMersenne32Randomizer,
+  generateMersenne53Randomizer,
+  type Randomizer,
+} from '@faker-js/faker';
+import { congruential32 } from './generator/congruential32';
+import { mersenne } from './generator/mersenne';
+import { xoroshiro128plus } from './generator/xoroshiro128plus';
+import { xorshift128plus } from './generator/xorshift128plus';
+import type { RandomGenerator } from './types/RandomGenerator';
+
+function generatePureRandRandomizer(factory: (seed: number) => RandomGenerator, initialSeed: number): Randomizer {
+  const self: { generator: RandomGenerator } & Randomizer = {
+    generator: factory(initialSeed),
+    next: () => (self.generator.next() >>> 0) / 0x1_0000_0000,
+    seed: (value) => {
+      self.generator = factory(typeof value === 'number' ? value : (value[0] ?? 0));
+    },
+  };
+  return self;
+}
+
+type Variant = { name: string; build: (seed: number) => Randomizer };
+
+const variants: Variant[] = [
+  { name: 'faker @@ mersenne32 (default <v9)', build: (seed) => generateMersenne32Randomizer(seed) },
+  { name: 'faker @@ mersenne53 (default >=v9)', build: (seed) => generateMersenne53Randomizer(seed) },
+  { name: 'pure-rand @@ xoroshiro128plus', build: (seed) => generatePureRandRandomizer(xoroshiro128plus, seed) },
+  { name: 'pure-rand @@ xorshift128plus', build: (seed) => generatePureRandRandomizer(xorshift128plus, seed) },
+  { name: 'pure-rand @@ mersenne', build: (seed) => generatePureRandRandomizer(mersenne, seed) },
+  { name: 'pure-rand @@ congruential32', build: (seed) => generatePureRandRandomizer(congruential32, seed) },
+];
+
+const numCalls = 5_000;
+
+describe('faker', () => {
+  describe(`randomizer.next() x ${numCalls}`, () => {
+    for (const { name, build } of variants) {
+      const randomizer = build(0);
+      bench(name, () => {
+        for (let i = 0; i !== numCalls; ++i) {
+          randomizer.next();
+        }
+      });
+    }
+  });
+
+  describe('faker.person.fullName()', () => {
+    for (const { name, build } of variants) {
+      const faker = new Faker({ locale: en, randomizer: build(0) });
+      bench(name, () => {
+        faker.person.fullName();
+      });
+    }
+  });
+
+  describe('faker.internet.email()', () => {
+    for (const { name, build } of variants) {
+      const faker = new Faker({ locale: en, randomizer: build(0) });
+      bench(name, () => {
+        faker.internet.email();
+      });
+    }
+  });
+
+  describe('faker.helpers.shuffle (1_000 items)', () => {
+    const data = Array.from({ length: 1_000 }, (_, i) => i);
+    for (const { name, build } of variants) {
+      const faker = new Faker({ locale: en, randomizer: build(0) });
+      bench(name, () => {
+        faker.helpers.shuffle(data);
+      });
+    }
+  });
+});


### PR DESCRIPTION
Wires faker through the `randomizer` option unlocked by the closed feature
request faker-js/faker#2195, so the default Mersenne-based randomizer can be
compared head-to-head against pure-rand generators on raw `next()` and on a
few realistic faker workloads (fullName, email, shuffle).