### PR TITLE
Move preview publishing into a dedicated job

### DIFF
--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -438,12 +438,6 @@ jobs:
         with:
           path: package.tgz
           key: bundle-main-${{ github.sha }}
-      - name: Preview (no comment)
-        if: github.event_name != 'pull_request'
-        run: pnpm exec pkg-pr-new publish --compact --comment=off
-      - name: Preview
-        if: github.event_name == 'pull_request'
-        run: pnpm exec pkg-pr-new publish --compact
 
   # Post-build jobs
   test_bundle:
@@ -509,6 +503,35 @@ jobs:
             echo "ERROR: Node version got updated from $NODE_VERSION to $(node --version)"
             exit 3
           fi
+  preview:
+    name: 'Preview'
+    needs:
+      - warmup_pnpm_cache
+      - production_package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Install pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+      - name: Using Node v24.x
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '24.15.0'
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+      - name: Download production package
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: bundle
+      - name: Unpack production package
+        run: tar -xzf package.tgz --strip-components=1
+      - name: Preview (no comment)
+        if: github.event_name != 'pull_request'
+        run: pnpm exec pkg-pr-new publish --compact --comment=off
+      - name: Preview
+        if: github.event_name == 'pull_request'
+        run: pnpm exec pkg-pr-new publish --compact
 
   # Job to confirm every required job passed
   pre_all_required_checks_passed:


### PR DESCRIPTION
Extract the "Preview" and "Preview (no comment)" steps out of the
production_package job into a standalone preview job that reuses the
built bundle artifact. This decouples pkg.pr.new preview publishing
from the required build so an external-service failure no longer
blocks merges.

https://claude.ai/code/session_017AXBDpmzYaghZCffYfHgCt