### PR TITLE
👷 Bench against both main and current build

### DIFF
--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -85,7 +85,7 @@ jobs:
         run: pnpm typecheck
   bench:
     name: 'Bench'
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.base_ref == 'main'
     needs: warmup_pnpm_cache
     runs-on: ubuntu-latest
     steps:
@@ -99,6 +99,29 @@ jobs:
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
+      # Build the current package: benchmarks run against the build (lib/), not the sources.
+      - name: Build current package
+        run: pnpm build
+      # Restore the bundle built out of main so that we can compare current against it.
+      - name: Restore main bundle from cache
+        id: main-cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: package.tgz
+          # Non-matching key so restore-keys picks the most recent main cache
+          key: bundle-main-will-not-match
+          restore-keys: bundle-main-
+      # Install the main version under the `pure-rand-main` alias. When no main bundle is
+      # cached yet (e.g. very first runs) we fall back to the latest published version.
+      - name: Install pure-rand from main
+        run: |
+          if [ -f package.tgz ]; then
+            echo "Comparing against the cached main bundle"
+            pnpm add "pure-rand-main@file:./package.tgz" --ignore-scripts
+          else
+            echo "::warning::No cached main bundle found, comparing against the latest published version"
+            pnpm add "pure-rand-main@npm:pure-rand@latest" --ignore-scripts
+          fi
       - name: Bench tests
         id: bench
         run: pnpm bench | tee bench-output.txt
@@ -112,7 +135,7 @@ jobs:
   comment_bench:
     name: 'Comment bench results'
     needs: bench
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.base_ref == 'main'
     runs-on: ubuntu-latest
     steps:
       - name: Download bench results

--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
     "test": "vitest",
     "test-bundle": "echo \"node: $(${NODE_BIN:-node} --version)\" && rm -rf test-bundle/*.mjs && for f in test-bundle/*.cjs; do if [ -f \"$f\" ]; then echo \"Creating ${f%.cjs}.mjs\" &&  mjs=\"${f%.cjs}.mjs\" && sed -E \"s/^const (\\{[^}]*\\}) = require\\(([^)]+)\\);$/import \\1 from \\2;/; s/^const ([a-zA-Z_][a-zA-Z0-9_]*) = require\\(([^)]+)\\);$/import \\1 from \\2;/; s/^'use strict';$//\" \"$f\" > \"$mjs\"; fi; done && for f in test-bundle/*.cjs test-bundle/*.mjs; do if [ -f \"$f\" ]; then echo \"Running ${f##*/}\" && ${NODE_BIN:-node} \"$f\" || exit 1; fi; done",
     "test-legacy-bundle": "nvs add 12.17.0 && NODE_BIN=$(nvs which 12.17.0) pnpm test-bundle",
-    "bench": "vitest bench"
+    "bench": "vitest bench",
+    "bench:setup": "pnpm add pure-rand-main@https://pkg.pr.new/dubzzz/pure-rand@main --ignore-scripts"
   },
   "repository": {
     "type": "git",

--- a/src/__bench__/Imports.ts
+++ b/src/__bench__/Imports.ts
@@ -1,0 +1,89 @@
+// Helper exposing two flavours of pure-rand so that benchmarks can compare the
+// performance of the change being worked on against the latest `main`:
+// - `current`: the freshly built package, taken from the `lib/` directory (the
+//   build, NOT the sources). Build it first with `pnpm build`.
+// - `main`: the version of pure-rand currently on `main`, installed under the
+//   `pure-rand-main` alias (run `pnpm bench:setup` locally to install it).
+//
+// Types are always taken from the sources so that typechecking keeps working
+// even when neither the build nor the `main` version are available locally.
+
+import type { congruential32 } from '../generator/congruential32';
+import type { mersenne } from '../generator/mersenne';
+import type { xoroshiro128plus } from '../generator/xoroshiro128plus';
+import type { xorshift128plus } from '../generator/xorshift128plus';
+import type { uniformInt } from '../distribution/uniformInt';
+import type { uniformBigInt } from '../distribution/uniformBigInt';
+import type { uniformFloat32 } from '../distribution/uniformFloat32';
+import type { uniformFloat64 } from '../distribution/uniformFloat64';
+
+// oxlint-disable typescript/ban-ts-comment
+// Current build, coming from the freshly built `lib/` directory (not the sources).
+// @ts-ignore - Only available once the package has been built (`pnpm build`)
+import { congruential32 as congruential32Current } from '../../lib/esm/generator/congruential32.js';
+// @ts-ignore - Only available once the package has been built (`pnpm build`)
+import { mersenne as mersenneCurrent } from '../../lib/esm/generator/mersenne.js';
+// @ts-ignore - Only available once the package has been built (`pnpm build`)
+import { xoroshiro128plus as xoroshiro128plusCurrent } from '../../lib/esm/generator/xoroshiro128plus.js';
+// @ts-ignore - Only available once the package has been built (`pnpm build`)
+import { xorshift128plus as xorshift128plusCurrent } from '../../lib/esm/generator/xorshift128plus.js';
+// @ts-ignore - Only available once the package has been built (`pnpm build`)
+import { uniformInt as uniformIntCurrent } from '../../lib/esm/distribution/uniformInt.js';
+// @ts-ignore - Only available once the package has been built (`pnpm build`)
+import { uniformBigInt as uniformBigIntCurrent } from '../../lib/esm/distribution/uniformBigInt.js';
+// @ts-ignore - Only available once the package has been built (`pnpm build`)
+import { uniformFloat32 as uniformFloat32Current } from '../../lib/esm/distribution/uniformFloat32.js';
+// @ts-ignore - Only available once the package has been built (`pnpm build`)
+import { uniformFloat64 as uniformFloat64Current } from '../../lib/esm/distribution/uniformFloat64.js';
+
+// Version currently on `main`, installed under the `pure-rand-main` alias.
+// @ts-ignore - Only available once `pnpm bench:setup` has been run
+import { congruential32 as congruential32Main } from 'pure-rand-main/generator/congruential32';
+// @ts-ignore - Only available once `pnpm bench:setup` has been run
+import { mersenne as mersenneMain } from 'pure-rand-main/generator/mersenne';
+// @ts-ignore - Only available once `pnpm bench:setup` has been run
+import { xoroshiro128plus as xoroshiro128plusMain } from 'pure-rand-main/generator/xoroshiro128plus';
+// @ts-ignore - Only available once `pnpm bench:setup` has been run
+import { xorshift128plus as xorshift128plusMain } from 'pure-rand-main/generator/xorshift128plus';
+// @ts-ignore - Only available once `pnpm bench:setup` has been run
+import { uniformInt as uniformIntMain } from 'pure-rand-main/distribution/uniformInt';
+// @ts-ignore - Only available once `pnpm bench:setup` has been run
+import { uniformBigInt as uniformBigIntMain } from 'pure-rand-main/distribution/uniformBigInt';
+// @ts-ignore - Only available once `pnpm bench:setup` has been run
+import { uniformFloat32 as uniformFloat32Main } from 'pure-rand-main/distribution/uniformFloat32';
+// @ts-ignore - Only available once `pnpm bench:setup` has been run
+import { uniformFloat64 as uniformFloat64Main } from 'pure-rand-main/distribution/uniformFloat64';
+// oxlint-enable typescript/ban-ts-comment
+
+export type PureRand = {
+  congruential32: typeof congruential32;
+  mersenne: typeof mersenne;
+  xoroshiro128plus: typeof xoroshiro128plus;
+  xorshift128plus: typeof xorshift128plus;
+  uniformInt: typeof uniformInt;
+  uniformBigInt: typeof uniformBigInt;
+  uniformFloat32: typeof uniformFloat32;
+  uniformFloat64: typeof uniformFloat64;
+};
+
+export const current: PureRand = {
+  congruential32: congruential32Current,
+  mersenne: mersenneCurrent,
+  xoroshiro128plus: xoroshiro128plusCurrent,
+  xorshift128plus: xorshift128plusCurrent,
+  uniformInt: uniformIntCurrent,
+  uniformBigInt: uniformBigIntCurrent,
+  uniformFloat32: uniformFloat32Current,
+  uniformFloat64: uniformFloat64Current,
+};
+
+export const main: PureRand = {
+  congruential32: congruential32Main,
+  mersenne: mersenneMain,
+  xoroshiro128plus: xoroshiro128plusMain,
+  xorshift128plus: xorshift128plusMain,
+  uniformInt: uniformIntMain,
+  uniformBigInt: uniformBigIntMain,
+  uniformFloat32: uniformFloat32Main,
+  uniformFloat64: uniformFloat64Main,
+};

--- a/src/distribution/distribution.bench.ts
+++ b/src/distribution/distribution.bench.ts
@@ -2,151 +2,125 @@ import { describe, bench } from 'vitest';
 import { current, main, type PureRand } from '../__bench__/Imports.js';
 import type { RandomGenerator } from '../types/RandomGenerator';
 
-type Version = { label: string; api: PureRand; rng: RandomGenerator };
-const versions: Version[] = [
-  { label: 'current', api: current, rng: current.xorshift128plus(0) },
-  { label: 'main', api: main, rng: main.xorshift128plus(0) },
-];
+// Run each version several times so that ordering/warmup noise gets averaged out
+// when comparing current against main.
+const numReplicas = 3;
 
-function benchVersions(name: string, run: (version: Version) => void): void {
-  for (const version of versions) {
-    bench(`${name} (${version.label})`, () => {
-      run(version);
-    });
-  }
+// Always compare the current build against main: each comparison gets its own
+// describe block holding `numReplicas` interleaved benches per version, named
+// `current-${i}` and `main-${i}`. Both versions are fed the same seeded generator
+// so the inputs are identical.
+function compare(name: string, run: (api: PureRand, rng: RandomGenerator) => void): void {
+  describe(name, () => {
+    for (let i = 0; i !== numReplicas; ++i) {
+      const rngCurrent = current.xorshift128plus(0);
+      const rngMain = main.xorshift128plus(0);
+      bench(`current-${i}`, () => {
+        run(current, rngCurrent);
+      });
+      bench(`main-${i}`, () => {
+        run(main, rngMain);
+      });
+    }
+  });
 }
 
 describe('distribution', () => {
   describe('pow2 ranges', () => {
     // range < 2 ** 8
     const smallRangeLabel = `{{S range}} [0, 2**4 -1]`;
-    bench(`native @@ ${smallRangeLabel}`, () => {
-      nativeInt(0, 15);
-    });
-    benchVersions(`uniformInt @@ ${smallRangeLabel}`, ({ api, rng }) => {
+    compare(`uniformInt @@ ${smallRangeLabel}`, (api, rng) => {
       api.uniformInt(rng, 0, 15);
     });
-    benchVersions(`uniformBigInt @@ ${smallRangeLabel}`, ({ api, rng }) => {
+    compare(`uniformBigInt @@ ${smallRangeLabel}`, (api, rng) => {
       api.uniformBigInt(rng, 0n, 15n);
     });
 
     // 2 ** 8 <= range < 2 ** 31
     const mediumRangeLabel = `{{M range}} [0, 2**21 -1]`;
-    bench(`native @@ ${mediumRangeLabel}`, () => {
-      nativeInt(0, 2097151);
-    });
-    benchVersions(`uniformInt @@ ${mediumRangeLabel}`, ({ api, rng }) => {
+    compare(`uniformInt @@ ${mediumRangeLabel}`, (api, rng) => {
       api.uniformInt(rng, 0, 2097151);
     });
-    benchVersions(`uniformBigInt @@ ${mediumRangeLabel}`, ({ api, rng }) => {
+    compare(`uniformBigInt @@ ${mediumRangeLabel}`, (api, rng) => {
       api.uniformBigInt(rng, 0n, 2097151n);
     });
 
     // 2 ** 31 <= range < 2 ** 32
     const largeRangeLabel = `{{L range}} [0, 2**32 -1]`;
-    bench(`native @@ ${largeRangeLabel}`, () => {
-      nativeInt(0, 4294967295);
-    });
-    benchVersions(`uniformInt @@ ${largeRangeLabel}`, ({ api, rng }) => {
+    compare(`uniformInt @@ ${largeRangeLabel}`, (api, rng) => {
       api.uniformInt(rng, 0, 4294967295);
     });
-    benchVersions(`uniformBigInt @@ ${largeRangeLabel}`, ({ api, rng }) => {
+    compare(`uniformBigInt @@ ${largeRangeLabel}`, (api, rng) => {
       api.uniformBigInt(rng, 0n, 4294967295n);
     });
 
     // 2 ** 32 <= range < Number.MAX_SAFE_INTEGER
     const veryLargeRangeLabel = `{{XL range}} [0, 2**40 -1]`;
-    bench(`native @@ ${largeRangeLabel}`, () => {
-      nativeInt(0, 1099511627775);
-    });
-    benchVersions(`uniformInt @@ ${veryLargeRangeLabel}`, ({ api, rng }) => {
+    compare(`uniformInt @@ ${veryLargeRangeLabel}`, (api, rng) => {
       api.uniformInt(rng, 0, 1099511627775);
     });
-    benchVersions(`uniformBigInt @@ ${veryLargeRangeLabel}`, ({ api, rng }) => {
+    compare(`uniformBigInt @@ ${veryLargeRangeLabel}`, (api, rng) => {
       api.uniformBigInt(rng, 0n, 1099511627775n);
     });
 
     // Number.MAX_SAFE_INTEGER << range
     // WARNING: "number" type cannot fit for such ranges
     const veryVeryLargeRangeLabel = `{{XXL range}} [0, 2**80 -1]`;
-    benchVersions(`uniformBigInt @@ ${veryVeryLargeRangeLabel}`, ({ api, rng }) => {
+    compare(`uniformBigInt @@ ${veryVeryLargeRangeLabel}`, (api, rng) => {
       api.uniformBigInt(rng, 0n, 1208925819614629174706175n);
     });
   });
 
   describe('various ranges', () => {
     // no specific range
-    bench(`native @@ {{float}} [0, 1)`, () => {
-      nativeFloat();
-    });
-    benchVersions(`uniformFloat32 @@ {{float}} [0, 1)`, ({ api, rng }) => {
+    compare(`uniformFloat32 @@ {{float}} [0, 1)`, (api, rng) => {
       api.uniformFloat32(rng);
     });
-    benchVersions(`uniformFloat64 @@ {{float}} [0, 1)`, ({ api, rng }) => {
+    compare(`uniformFloat64 @@ {{float}} [0, 1)`, (api, rng) => {
       api.uniformFloat64(rng);
     });
 
     // range < 2 ** 8
     const smallRangeLabel = `{{S range}} [0, 48]`;
-    bench(`native @@ ${smallRangeLabel}`, () => {
-      nativeInt(0, 48);
-    });
-    benchVersions(`uniformInt @@ ${smallRangeLabel}`, ({ api, rng }) => {
+    compare(`uniformInt @@ ${smallRangeLabel}`, (api, rng) => {
       api.uniformInt(rng, 0, 48);
     });
-    benchVersions(`uniformBigInt @@ ${smallRangeLabel}`, ({ api, rng }) => {
+    compare(`uniformBigInt @@ ${smallRangeLabel}`, (api, rng) => {
       api.uniformBigInt(rng, 0n, 48n);
     });
 
     // 2 ** 8 <= range < 2 ** 31
     const mediumRangeLabel = `{{M range}} [0, 1_000_000_000]`;
-    bench(`native @@ ${mediumRangeLabel}`, () => {
-      nativeInt(0, 1_000_000_000);
-    });
-    benchVersions(`uniformInt @@ ${mediumRangeLabel}`, ({ api, rng }) => {
+    compare(`uniformInt @@ ${mediumRangeLabel}`, (api, rng) => {
       api.uniformInt(rng, 0, 1_000_000_000);
     });
-    benchVersions(`uniformBigInt @@ ${mediumRangeLabel}`, ({ api, rng }) => {
+    compare(`uniformBigInt @@ ${mediumRangeLabel}`, (api, rng) => {
       api.uniformBigInt(rng, 0n, 1_000_000_000n);
     });
 
     // 2 ** 31 <= range < 2 ** 32
     const largeRangeLabel = `{{L range}} [0, 4_000_000_000]`;
-    bench(`native @@ ${largeRangeLabel}`, () => {
-      nativeInt(0, 4_000_000_000);
-    });
-    benchVersions(`uniformInt @@ ${largeRangeLabel}`, ({ api, rng }) => {
+    compare(`uniformInt @@ ${largeRangeLabel}`, (api, rng) => {
       api.uniformInt(rng, 0, 4_000_000_000);
     });
-    benchVersions(`uniformBigInt @@ ${largeRangeLabel}`, ({ api, rng }) => {
+    compare(`uniformBigInt @@ ${largeRangeLabel}`, (api, rng) => {
       api.uniformBigInt(rng, 0n, 4_000_000_000n);
     });
 
     // 2 ** 32 <= range < Number.MAX_SAFE_INTEGER
     const veryLargeRangeLabel = `{{XL range}} [0, 8_000_000_000]`;
-    bench(`native @@ ${veryLargeRangeLabel}`, () => {
-      nativeInt(0, 8_000_000_000);
-    });
-    benchVersions(`uniformInt @@ ${veryLargeRangeLabel}`, ({ api, rng }) => {
+    compare(`uniformInt @@ ${veryLargeRangeLabel}`, (api, rng) => {
       api.uniformInt(rng, 0, 8_000_000_000);
     });
-    benchVersions(`uniformBigInt @@ ${veryLargeRangeLabel}`, ({ api, rng }) => {
+    compare(`uniformBigInt @@ ${veryLargeRangeLabel}`, (api, rng) => {
       api.uniformBigInt(rng, 0n, 8_000_000_000n);
     });
 
     // Number.MAX_SAFE_INTEGER << range
     // WARNING: "number" type cannot fit for such ranges
     const veryVeryLargeRangeLabel = `{{XXL range}} [0, 100_000_000_000_000_000]`;
-    benchVersions(`uniformBigInt @@ ${veryVeryLargeRangeLabel}`, ({ api, rng }) => {
+    compare(`uniformBigInt @@ ${veryVeryLargeRangeLabel}`, (api, rng) => {
       api.uniformBigInt(rng, 0n, 100_000_000_000_000_000n);
     });
   });
 });
-
-function nativeFloat() {
-  return Math.random();
-}
-
-function nativeInt(from: number, to: number) {
-  return from + Math.floor(Math.random() * (to - from + 1));
-}

--- a/src/distribution/distribution.bench.ts
+++ b/src/distribution/distribution.bench.ts
@@ -1,24 +1,33 @@
 import { describe, bench } from 'vitest';
-import { xorshift128plus } from '../generator/xorshift128plus';
-import { uniformInt } from './uniformInt';
-import { uniformBigInt } from './uniformBigInt';
-import { uniformFloat32 } from './uniformFloat32';
-import { uniformFloat64 } from './uniformFloat64';
+import { current, main, type PureRand } from '../__bench__/Imports.js';
+import type { RandomGenerator } from '../types/RandomGenerator';
+
+type Version = { label: string; api: PureRand; rng: RandomGenerator };
+const versions: Version[] = [
+  { label: 'current', api: current, rng: current.xorshift128plus(0) },
+  { label: 'main', api: main, rng: main.xorshift128plus(0) },
+];
+
+function benchVersions(name: string, run: (version: Version) => void): void {
+  for (const version of versions) {
+    bench(`${name} (${version.label})`, () => {
+      run(version);
+    });
+  }
+}
 
 describe('distribution', () => {
-  const rng = xorshift128plus(0);
-
   describe('pow2 ranges', () => {
     // range < 2 ** 8
     const smallRangeLabel = `{{S range}} [0, 2**4 -1]`;
     bench(`native @@ ${smallRangeLabel}`, () => {
       nativeInt(0, 15);
     });
-    bench(`uniformInt @@ ${smallRangeLabel}`, () => {
-      uniformInt(rng, 0, 15);
+    benchVersions(`uniformInt @@ ${smallRangeLabel}`, ({ api, rng }) => {
+      api.uniformInt(rng, 0, 15);
     });
-    bench(`uniformBigInt @@ ${smallRangeLabel}`, () => {
-      uniformBigInt(rng, 0n, 15n);
+    benchVersions(`uniformBigInt @@ ${smallRangeLabel}`, ({ api, rng }) => {
+      api.uniformBigInt(rng, 0n, 15n);
     });
 
     // 2 ** 8 <= range < 2 ** 31
@@ -26,11 +35,11 @@ describe('distribution', () => {
     bench(`native @@ ${mediumRangeLabel}`, () => {
       nativeInt(0, 2097151);
     });
-    bench(`uniformInt @@ ${mediumRangeLabel}`, () => {
-      uniformInt(rng, 0, 2097151);
+    benchVersions(`uniformInt @@ ${mediumRangeLabel}`, ({ api, rng }) => {
+      api.uniformInt(rng, 0, 2097151);
     });
-    bench(`uniformBigInt @@ ${mediumRangeLabel}`, () => {
-      uniformBigInt(rng, 0n, 2097151n);
+    benchVersions(`uniformBigInt @@ ${mediumRangeLabel}`, ({ api, rng }) => {
+      api.uniformBigInt(rng, 0n, 2097151n);
     });
 
     // 2 ** 31 <= range < 2 ** 32
@@ -38,11 +47,11 @@ describe('distribution', () => {
     bench(`native @@ ${largeRangeLabel}`, () => {
       nativeInt(0, 4294967295);
     });
-    bench(`uniformInt @@ ${largeRangeLabel}`, () => {
-      uniformInt(rng, 0, 4294967295);
+    benchVersions(`uniformInt @@ ${largeRangeLabel}`, ({ api, rng }) => {
+      api.uniformInt(rng, 0, 4294967295);
     });
-    bench(`uniformBigInt @@ ${largeRangeLabel}`, () => {
-      uniformBigInt(rng, 0n, 4294967295n);
+    benchVersions(`uniformBigInt @@ ${largeRangeLabel}`, ({ api, rng }) => {
+      api.uniformBigInt(rng, 0n, 4294967295n);
     });
 
     // 2 ** 32 <= range < Number.MAX_SAFE_INTEGER
@@ -50,18 +59,18 @@ describe('distribution', () => {
     bench(`native @@ ${largeRangeLabel}`, () => {
       nativeInt(0, 1099511627775);
     });
-    bench(`uniformInt @@ ${veryLargeRangeLabel}`, () => {
-      uniformInt(rng, 0, 1099511627775);
+    benchVersions(`uniformInt @@ ${veryLargeRangeLabel}`, ({ api, rng }) => {
+      api.uniformInt(rng, 0, 1099511627775);
     });
-    bench(`uniformBigInt @@ ${veryLargeRangeLabel}`, () => {
-      uniformBigInt(rng, 0n, 1099511627775n);
+    benchVersions(`uniformBigInt @@ ${veryLargeRangeLabel}`, ({ api, rng }) => {
+      api.uniformBigInt(rng, 0n, 1099511627775n);
     });
 
     // Number.MAX_SAFE_INTEGER << range
     // WARNING: "number" type cannot fit for such ranges
     const veryVeryLargeRangeLabel = `{{XXL range}} [0, 2**80 -1]`;
-    bench(`uniformBigInt @@ ${veryVeryLargeRangeLabel}`, () => {
-      uniformBigInt(rng, 0n, 1208925819614629174706175n);
+    benchVersions(`uniformBigInt @@ ${veryVeryLargeRangeLabel}`, ({ api, rng }) => {
+      api.uniformBigInt(rng, 0n, 1208925819614629174706175n);
     });
   });
 
@@ -70,11 +79,11 @@ describe('distribution', () => {
     bench(`native @@ {{float}} [0, 1)`, () => {
       nativeFloat();
     });
-    bench(`uniformFloat32 @@ {{float}} [0, 1)`, () => {
-      uniformFloat32(rng);
+    benchVersions(`uniformFloat32 @@ {{float}} [0, 1)`, ({ api, rng }) => {
+      api.uniformFloat32(rng);
     });
-    bench(`uniformFloat64 @@ {{float}} [0, 1)`, () => {
-      uniformFloat64(rng);
+    benchVersions(`uniformFloat64 @@ {{float}} [0, 1)`, ({ api, rng }) => {
+      api.uniformFloat64(rng);
     });
 
     // range < 2 ** 8
@@ -82,11 +91,11 @@ describe('distribution', () => {
     bench(`native @@ ${smallRangeLabel}`, () => {
       nativeInt(0, 48);
     });
-    bench(`uniformInt @@ ${smallRangeLabel}`, () => {
-      uniformInt(rng, 0, 48);
+    benchVersions(`uniformInt @@ ${smallRangeLabel}`, ({ api, rng }) => {
+      api.uniformInt(rng, 0, 48);
     });
-    bench(`uniformBigInt @@ ${smallRangeLabel}`, () => {
-      uniformBigInt(rng, 0n, 48n);
+    benchVersions(`uniformBigInt @@ ${smallRangeLabel}`, ({ api, rng }) => {
+      api.uniformBigInt(rng, 0n, 48n);
     });
 
     // 2 ** 8 <= range < 2 ** 31
@@ -94,11 +103,11 @@ describe('distribution', () => {
     bench(`native @@ ${mediumRangeLabel}`, () => {
       nativeInt(0, 1_000_000_000);
     });
-    bench(`uniformInt @@ ${mediumRangeLabel}`, () => {
-      uniformInt(rng, 0, 1_000_000_000);
+    benchVersions(`uniformInt @@ ${mediumRangeLabel}`, ({ api, rng }) => {
+      api.uniformInt(rng, 0, 1_000_000_000);
     });
-    bench(`uniformBigInt @@ ${mediumRangeLabel}`, () => {
-      uniformBigInt(rng, 0n, 1_000_000_000n);
+    benchVersions(`uniformBigInt @@ ${mediumRangeLabel}`, ({ api, rng }) => {
+      api.uniformBigInt(rng, 0n, 1_000_000_000n);
     });
 
     // 2 ** 31 <= range < 2 ** 32
@@ -106,11 +115,11 @@ describe('distribution', () => {
     bench(`native @@ ${largeRangeLabel}`, () => {
       nativeInt(0, 4_000_000_000);
     });
-    bench(`uniformInt @@ ${largeRangeLabel}`, () => {
-      uniformInt(rng, 0, 4_000_000_000);
+    benchVersions(`uniformInt @@ ${largeRangeLabel}`, ({ api, rng }) => {
+      api.uniformInt(rng, 0, 4_000_000_000);
     });
-    bench(`uniformBigInt @@ ${largeRangeLabel}`, () => {
-      uniformBigInt(rng, 0n, 4_000_000_000n);
+    benchVersions(`uniformBigInt @@ ${largeRangeLabel}`, ({ api, rng }) => {
+      api.uniformBigInt(rng, 0n, 4_000_000_000n);
     });
 
     // 2 ** 32 <= range < Number.MAX_SAFE_INTEGER
@@ -118,18 +127,18 @@ describe('distribution', () => {
     bench(`native @@ ${veryLargeRangeLabel}`, () => {
       nativeInt(0, 8_000_000_000);
     });
-    bench(`uniformInt @@ ${veryLargeRangeLabel}`, () => {
-      uniformInt(rng, 0, 8_000_000_000);
+    benchVersions(`uniformInt @@ ${veryLargeRangeLabel}`, ({ api, rng }) => {
+      api.uniformInt(rng, 0, 8_000_000_000);
     });
-    bench(`uniformBigInt @@ ${veryLargeRangeLabel}`, () => {
-      uniformBigInt(rng, 0n, 8_000_000_000n);
+    benchVersions(`uniformBigInt @@ ${veryLargeRangeLabel}`, ({ api, rng }) => {
+      api.uniformBigInt(rng, 0n, 8_000_000_000n);
     });
 
     // Number.MAX_SAFE_INTEGER << range
     // WARNING: "number" type cannot fit for such ranges
     const veryVeryLargeRangeLabel = `{{XXL range}} [0, 100_000_000_000_000_000]`;
-    bench(`uniformBigInt @@ ${veryVeryLargeRangeLabel}`, () => {
-      uniformBigInt(rng, 0n, 100_000_000_000_000_000n);
+    benchVersions(`uniformBigInt @@ ${veryVeryLargeRangeLabel}`, ({ api, rng }) => {
+      api.uniformBigInt(rng, 0n, 100_000_000_000_000_000n);
     });
   });
 });

--- a/src/generator/generator.bench.ts
+++ b/src/generator/generator.bench.ts
@@ -1,96 +1,75 @@
 import { describe, bench } from 'vitest';
 import { current, main, type PureRand } from '../__bench__/Imports.js';
-import type { JumpableRandomGenerator } from '../types/JumpableRandomGenerator';
-import type { RandomGenerator } from '../types/RandomGenerator';
 
 const numInts = 5_000;
+
+// Run each version several times so that ordering/warmup noise gets averaged out
+// when comparing current against main.
+const numReplicas = 3;
 
 type GeneratorName = 'congruential32' | 'mersenne' | 'xoroshiro128plus' | 'xorshift128plus';
 const generatorNames: GeneratorName[] = ['congruential32', 'mersenne', 'xoroshiro128plus', 'xorshift128plus'];
 
-type Version = { label: string; api: PureRand };
-const versions: Version[] = [
-  { label: 'current', api: current },
-  { label: 'main', api: main },
-];
+// Always compare the current build against main: each comparison gets its own
+// describe block holding `numReplicas` interleaved benches per version, named
+// `current-${i}` and `main-${i}`.
+function compare(name: string, make: (api: PureRand) => () => void): void {
+  describe(name, () => {
+    for (let i = 0; i !== numReplicas; ++i) {
+      bench(`current-${i}`, make(current));
+      bench(`main-${i}`, make(main));
+    }
+  });
+}
 
 describe('generator', () => {
   describe(`init and ${numInts} next`, () => {
-    bench('native', () => {
-      const rng = native();
-      for (let i = 0; i !== numInts; ++i) {
-        rng.next();
-      }
-    });
     for (const name of generatorNames) {
-      for (const { label, api } of versions) {
+      compare(name, (api) => {
         let seed = 0;
-        bench(`${name} (${label})`, () => {
+        return () => {
           const rng = api[name](seed++);
           for (let i = 0; i !== numInts; ++i) {
             rng.next();
           }
-        });
-      }
+        };
+      });
     }
   });
 
   describe(`${numInts} next`, () => {
-    bench('native', () => {
-      const rng = native();
-      for (let i = 0; i !== numInts; ++i) {
-        rng.next();
-      }
-    });
     for (const name of generatorNames) {
-      for (const { label, api } of versions) {
+      compare(name, (api) => {
         const rng = api[name](0);
-        bench(`${name} (${label})`, () => {
+        return () => {
           for (let i = 0; i !== numInts; ++i) {
             rng.next();
           }
-        });
-      }
+        };
+      });
     }
   });
 
   for (const name of generatorNames) {
     describe(name, () => {
-      for (const { label, api } of versions) {
-        const rng = api[name](0);
+      compare('init', (api) => {
         let seed = 0;
-        bench(
-          `init (${label})`,
-          () => {
-            api[name](seed);
-          },
-          {
-            setup: () => {
-              seed = (seed + 1) | 0;
-            },
-          },
-        );
-        bench(`next (${label})`, () => {
+        return () => {
+          api[name]((seed = (seed + 1) | 0));
+        };
+      });
+      compare('next', (api) => {
+        const rng = api[name](0);
+        return () => {
           rng.next();
-        });
-        if (isJumpableRandomGenerator(rng)) {
-          bench(`jump (${label})`, () => {
-            rng.jump();
-          });
-        }
-      }
+        };
+      });
+      compare('jump', (api) => {
+        const rng = api[name](0);
+        return () => {
+          rng.jump();
+        };
+      });
     });
   }
 });
-
-function native(): RandomGenerator {
-  return {
-    clone: () => native(),
-    getState: () => [],
-    next: () => Math.random(),
-  };
-}
-
-function isJumpableRandomGenerator(rng: RandomGenerator): rng is JumpableRandomGenerator {
-  return 'jump' in rng;
-}

--- a/src/generator/generator.bench.ts
+++ b/src/generator/generator.bench.ts
@@ -1,61 +1,83 @@
 import { describe, bench } from 'vitest';
-import { xoroshiro128plus } from './xoroshiro128plus';
-import { congruential32 } from './congruential32';
-import { mersenne } from './mersenne';
-import { xorshift128plus } from './xorshift128plus';
+import { current, main, type PureRand } from '../__bench__/Imports.js';
 import type { JumpableRandomGenerator } from '../types/JumpableRandomGenerator';
 import type { RandomGenerator } from '../types/RandomGenerator';
 
 const numInts = 5_000;
-const algorithms = [native, congruential32, mersenne, xoroshiro128plus, xorshift128plus];
+
+type GeneratorName = 'congruential32' | 'mersenne' | 'xoroshiro128plus' | 'xorshift128plus';
+const generatorNames: GeneratorName[] = ['congruential32', 'mersenne', 'xoroshiro128plus', 'xorshift128plus'];
+
+type Version = { label: string; api: PureRand };
+const versions: Version[] = [
+  { label: 'current', api: current },
+  { label: 'main', api: main },
+];
 
 describe('generator', () => {
   describe(`init and ${numInts} next`, () => {
-    for (const algorithm of algorithms) {
-      let seed = 0;
-      bench(algorithm.name, () => {
-        const rng = algorithm(seed++);
-        for (let i = 0; i !== numInts; ++i) {
-          rng.next();
-        }
-      });
-    }
-  });
-  describe(`${numInts} next`, () => {
-    for (const algorithm of algorithms) {
-      const rng = algorithm(0);
-      bench(algorithm.name, () => {
-        for (let i = 0; i !== numInts; ++i) {
-          rng.next();
-        }
-      });
-    }
-  });
-  for (const algorithm of algorithms) {
-    if (algorithm === native) {
-      continue;
-    }
-    describe(algorithm.name, () => {
-      const rng = algorithm(0);
-      let seed = 0;
-      bench(
-        'init',
-        () => {
-          algorithm(seed);
-        },
-        {
-          setup: () => {
-            seed = (seed + 1) | 0;
-          },
-        },
-      );
-      bench('next', () => {
+    bench('native', () => {
+      const rng = native();
+      for (let i = 0; i !== numInts; ++i) {
         rng.next();
-      });
-      if (isJumpableRandomGenerator(rng)) {
-        bench('jump', () => {
-          rng.jump();
+      }
+    });
+    for (const name of generatorNames) {
+      for (const { label, api } of versions) {
+        let seed = 0;
+        bench(`${name} (${label})`, () => {
+          const rng = api[name](seed++);
+          for (let i = 0; i !== numInts; ++i) {
+            rng.next();
+          }
         });
+      }
+    }
+  });
+
+  describe(`${numInts} next`, () => {
+    bench('native', () => {
+      const rng = native();
+      for (let i = 0; i !== numInts; ++i) {
+        rng.next();
+      }
+    });
+    for (const name of generatorNames) {
+      for (const { label, api } of versions) {
+        const rng = api[name](0);
+        bench(`${name} (${label})`, () => {
+          for (let i = 0; i !== numInts; ++i) {
+            rng.next();
+          }
+        });
+      }
+    }
+  });
+
+  for (const name of generatorNames) {
+    describe(name, () => {
+      for (const { label, api } of versions) {
+        const rng = api[name](0);
+        let seed = 0;
+        bench(
+          `init (${label})`,
+          () => {
+            api[name](seed);
+          },
+          {
+            setup: () => {
+              seed = (seed + 1) | 0;
+            },
+          },
+        );
+        bench(`next (${label})`, () => {
+          rng.next();
+        });
+        if (isJumpableRandomGenerator(rng)) {
+          bench(`jump (${label})`, () => {
+            rng.jump();
+          });
+        }
       }
     });
   }


### PR DESCRIPTION
Adapt benchmarks and the bench CI step to compare the current build (lib/)
against the version on main, mirroring dubzzz/fast-check@b9334a6.

- Add src/__bench__/Imports.ts exposing the current build (from lib/) and the
  main version (installed as the pure-rand-main alias), typed from the sources.
- Rewrite generator/distribution benchmarks to run each case for both versions.
- Add a bench:setup script to install the main version locally.
- Update the bench CI job to build the current package, restore the cached main
  bundle (falling back to the latest published version) and run benches against
  both. Gate bench/comment_bench on PRs targeting main.